### PR TITLE
fix: transmission_telegram_notification.sh

### DIFF
--- a/src/transmission_telegram_notification.sh
+++ b/src/transmission_telegram_notification.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Bot token
 BOT_TOKEN="ADD_YOUR_TELEGRAM_BOT_TOKEN"
@@ -8,13 +8,20 @@ CHAT_ID="ADD_YOUR_TELEGRAM_CHAT_ID"
 
 # Notification message
 # If you need a line break, use "%0A" instead of "\n".
-MESSAGE="<strong>Download Completed</strong>%0A- ${TR_TORRENT_NAME}%0A"
+MESSAGE="✅ <strong>Download Completed</strong>%0A- ${TR_TORRENT_NAME}%0A"
 
-# Prepares the request payload
-PAYLOAD="https://api.telegram.org/bot${BOT_TOKEN}/sendMessage?chat_id=${CHAT_ID}&text=${MESSAGE}&parse_mode=HTML"
+# Prepares the request url
+TG_WEBHOOK_URL="https://api.telegram.org/bot${BOT_TOKEN}/sendMessage"
+
+# Prepares the the directory for saving the logs
+BASEDIR=$(dirname "$0")
 
 # Sends the notification to the telegram bot and save the response content into the notificationsLog.txt
-curl -S -X POST "${PAYLOAD}" -w "\n\n" | sudo tee -a notificationsLog.txt
+curl -S -X POST \
+  -d chat_id="${CHAT_ID}" \
+  -d text="${MESSAGE}" \
+  -d parse_mode="HTML" \
+  "${TG_WEBHOOK_URL}" -w "\n" | tee -a "${BASEDIR}/notificationsLog.txt"
 
 # Prints a info message in the console
 echo "[${TR_TIME_LOCALTIME}]-[${TR_TORRENT_NAME}] Download completed. Telegram notification sent."


### PR DESCRIPTION
- Encode the url parameters before sending to telegram api
- Update message content to have the check emoji
- Saves the log file to the script directory by default
- Use `/bin/sh` as shebang to make script portable

After the change it fixes the issue and updates the telegram message to have the check emoji, screenshot:
![Screenshot from 2023-10-16 16-05-26](https://github.com/rteixeirax/transmission-telegram-notifications/assets/1276544/2707b4bc-eb7b-47b6-a222-36f68edd5ab6)

Fixes: #1